### PR TITLE
added binary_operator_spaces rule

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -18,6 +18,7 @@ return PhpCsFixer\Config::create()
             'array_syntax' => ['syntax' => 'short'],
             'declare_strict_types' => true,
             'yoda_style' => ['equal' => false, 'identical' => false, 'less_and_greater' => false],
+            'binary_operator_spaces' => ['default' => null],
         ]
     )
     ->setFinder($finder);


### PR DESCRIPTION
I found the following rule to be useful:
`'binary_operator_spaces' => ['default' => null],`

Will prevent indentations to be dropped within array arguments e.g.
```
[
    'foo'    => 'bar',
    'bar'    => 'foo',
    'foobar' => true,
]
```