### PR TITLE
Use more github templates

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+# Prerequisites
+
+Please, before creating this issue make sure that you read the [README](https://github.com/FriendsOfShopware/default-plugin-repo/blob/master/README.md), that you are running the latest stable version of this plugin and that you already searched [other issues](https://github.com/FriendsOfShopware/default-plugin-repo/issues?q=is%3Aissue+is%3Aopen+is%3Aclosed) to see if your problem or request was already reported.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,3 +1,9 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
 # Prerequisites
 
 Please, before creating this issue make sure that you read the [README](https://github.com/FriendsOfShopware/default-plugin-repo/blob/master/README.md), that you are running the latest stable version of this plugin and that you already searched [other issues](https://github.com/FriendsOfShopware/default-plugin-repo/issues?q=is%3Aissue+is%3Aopen+is%3Aclosed) to see if your problem or request was already reported.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+<!--
+# Prerequisites
+
+Please, before creating this issue make sure that you read the [README](https://github.com/FriendsOfShopware/default-plugin-repo/blob/master/README.md), that you are running the latest stable version of this plugin and that you already searched [other issues](https://github.com/FriendsOfShopware/default-plugin-repo/issues?q=is%3Aissue+is%3Aopen+is%3Aclosed) to see if your problem or request was already reported.
+-->
+
+## Actual behaviour
+<!--   Please describe the correct state-->
+
+## Wanted feature
+<!--  What you expect to happen -->
+
+## Reason for this request
+<!-- Why should be the plugin changed or extended -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+## Description
+<!--- Describe your changes -->
+
+## Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an open issue, please link to the issue here. -->
+
+## Screenshots/links (if appropriate):


### PR DESCRIPTION
- moved everything to .github folder
- .github/CONTRIBUTING.md is linked on several places (even more for first time contributors)
- github allows multiple templates for e.g. bugs/features/documentation .... (didn't change the content - maybe Frosh should with .github/CONTRIBUTING.md in place)
- .github/ISSUE_TEMPLATE/feature_request.md added a feature template (commented out the hints - different compared to bug)
- .github/PULL_REQUEST_TEMPLATE.md added a simple pull request template aswell.

(GitHub also allows a code of conduct file)